### PR TITLE
Rewrite to incorporate type-preserving functions

### DIFF
--- a/src/camel_snake_kebab.clj
+++ b/src/camel_snake_kebab.clj
@@ -1,45 +1,75 @@
 (ns camel-snake-kebab
-  (:use [clojure.string :only (split join capitalize lower-case upper-case)])
+  (:require (clojure (string :refer [split join capitalize
+                                     lower-case upper-case])))
   (:import (clojure.lang Keyword Symbol)))
 
-(defprotocol Stringish
-  (transform [this f]))
+(def ^:private upper-case-http-headers
+  "Headers that are matched against for converting to HTTP-Header_Case."
+  #{"CPU" "DNT" "IP" "SSL" "TE" "UA" "WAP" "XSS"})
 
-(extend-protocol Stringish
-  String  (transform [this f] (-> this f))
-  Keyword (transform [this f] (-> this name f keyword))
-  Symbol  (transform [this f] (-> this name f symbol)))
-
-(def ^:private word-separators
-  [" ", "_", "-"
- ; http://stackoverflow.com/a/2560017/339785 :
-   "(?<=[A-Z])(?=[A-Z][a-z])"
-   "(?<=[^A-Z_])(?=[A-Z])"
-   "(?<=[A-Za-z])(?=[^A-Za-z])"])
-
-(def ^:private word-separator-pattern
-  (->> word-separators (join "|") re-pattern))
-
-(def ^:private parse
-  #(split % word-separator-pattern))
-
-(defn format-case [first-fn rest-fn separator stringish]
-  (letfn [(unparse [[first & rest]] (join separator (cons (first-fn first) (map rest-fn rest))))]
-    (transform stringish (comp unparse parse))))
-
-(def ->CamelCase  (partial format-case capitalize capitalize ""))
-(def ->camelCase  (partial format-case lower-case capitalize ""))
-(def ->SNAKE_CASE (partial format-case upper-case upper-case "_"))
-(def ->Snake_case (partial format-case capitalize lower-case "_"))
-(def ->snake_case (partial format-case lower-case lower-case "_"))
-(def ->kebab-case (partial format-case lower-case lower-case "-"))
-
-(def ->Camel_Snake_Case (partial format-case capitalize capitalize "_"))
-
-(def upper-case-http-headers #{"CPU" "DNT" "IP" "SSL" "TE" "UA" "WAP" "XSS"})
-
-(defn- capitalize-http-header [x]
+(defn- capitalize-http-header
+  "Uppercase x if it is an HTTP header, capitalize it otherwise."
+  [x]
   (or (upper-case-http-headers (upper-case x))
       (capitalize x)))
 
-(def ->HTTP-Header-Case (partial format-case capitalize-http-header capitalize-http-header "-"))
+(def ^:private word-separator-pattern
+  "A pattern that matches all known word separators."
+  (->> [" " "_" "-"
+        "(?<=[A-Z])(?=[A-Z][a-z])"
+        "(?<=[^A-Z_-])(?=[A-Z])"
+        "(?<=[A-Za-z])(?=[^A-Za-z])"]
+       (join "|")
+       re-pattern))
+
+(defn- convert-case [first-fn rest-fn separator s]
+  "Converts the case of a string s according to the rule for the first
+  word, remaining words, and the separator."
+  (-> s
+      (split word-separator-pattern)
+      ((fn [[word & more]]
+         (join separator (cons (first-fn word) (map rest-fn more)))))))
+
+(def ^:private case-conversion-rules
+  "The formatting rules for each case."
+  {"CamelCase" [capitalize capitalize ""]
+   "Camel_Snake_Case" [capitalize capitalize "_"]
+   "Camel-Kebab-Case" [capitalize capitalize "-"]
+   "camelCase" [lower-case capitalize ""]
+   "camel_Snake_Case" [lower-case capitalize "_"]
+   "camel-Kebab-Case" [lower-case capitalize "-"]
+   "Snake_case" [capitalize lower-case "_"]
+   "Kebab-case" [capitalize lower-case "-"]
+   "SNAKE_CASE" [upper-case upper-case "_"]
+   "KEBAB-CASE" [upper-case upper-case "-"]
+   "snake_case" [lower-case lower-case "_"]
+   "kebab-case" [lower-case lower-case "-"]
+   "HTTP-Header-Case" [capitalize-http-header capitalize-http-header "-"]})
+
+(defprotocol AlterName
+  (alter-name [this f] "Alters the name of this with f."))
+
+(extend-protocol AlterName
+  String (alter-name [this f] (-> this f))
+  Keyword (alter-name [this f] (-> this name f keyword))
+  Symbol (alter-name [this f] (-> this name f symbol)))
+
+(doseq [[case-label [first-fn rest-fn separator]] case-conversion-rules]
+  (let [case-converter (partial convert-case first-fn rest-fn separator)
+        symbol-creator (fn [type-label]
+                         (->> [case-label type-label]
+                              (join \space)
+                              case-converter
+                              (format "->%s")
+                              symbol))]
+    ;; Create the type-preserving functions.
+    (intern *ns*
+            (->> case-label (format "->%s") symbol)
+            #(alter-name % case-converter))
+    ;; Create the string-returning functions.
+    (intern *ns* (symbol-creator "string") (comp case-converter name))
+    (doseq [[type-label type-converter] {"symbol" symbol "keyword" keyword}]
+      ;; Create the symbol- and keyword-returning.
+      (intern *ns*
+              (symbol-creator type-label)
+              (comp type-converter case-converter name)))))


### PR DESCRIPTION
Here is a full rewrite that exposes all of the functions from the existing release and more.  It goes from the 8 conversion functions to a set of 13, and implements 3 additional variations for each one based on the return type as discussed.  Thus, there are 52 public conversion functions, plus the AlterName and alter-name protocol functions in the namespace.

It is backwards compatible except for the exposure of the protocol functions (which weren't meant to be part of the API anyway).
