### PR TITLE
save one identity call for non-converting fns

### DIFF
--- a/src/camel_snake_kebab/internals/macros.clj
+++ b/src/camel_snake_kebab/internals/macros.clj
@@ -4,22 +4,23 @@
 
 (defn type-preserving-function [case-label first-fn rest-fn sep]
   `(let [convert-case# (partial convert-case ~first-fn ~rest-fn ~sep)]
-     (defn ~(->> case-label (format "->%s") symbol) [s#]
+     (defn ~(symbol (str "->" case-label)) [s#]
        (camel-snake-kebab.core/alter-name s# convert-case#))))
 
 (defn type-converting-functions [case-label first-fn rest-fn sep]
   (letfn [(make-name [type-label]
-            (->> [case-label type-label]
-                 (join \space)
+            (->> (str case-label " " type-label)
                  (convert-case (resolve first-fn) (resolve rest-fn) sep)
-                 (format "->%s")
-                 (symbol)))]
-    (for [[type-label type-converter] {"string" `identity "symbol" `symbol "keyword" `keyword}]
-      `(defn ~(make-name type-label) [s#]
-         (->> s#
-              name
-              (convert-case ~first-fn ~rest-fn ~sep)
-              ~type-converter)))))
+                 (str "->")
+                 symbol))]
+    (for [[type-label type-converter] {"string" nil
+                                       "symbol" 'symbol
+                                       "keyword" 'keyword}]
+      (if type-converter
+        `(defn ~(make-name type-label) [s#]
+           (~type-converter (convert-case ~first-fn ~rest-fn ~sep (name s#))))
+        `(defn ~(make-name type-label) [s#]
+           (convert-case ~first-fn ~rest-fn ~sep (name s#)))))))
 
 (defmacro defconversion [case-label first-fn rest-fn sep]
   `(do  ~(type-preserving-function  case-label first-fn rest-fn sep)


### PR DESCRIPTION
- playing round with the code, thought it would't be so terrible to
  remove the unneeded identity call. Save you a couple nanoseconds ;)
- also messed around with a little stylistic things that you may or may
  not actually like, which I'm too lazy to separate out into a separate
  commit.  Let me know if you dislike them and I can remove them from this commit.
