### PR TITLE
Avoid name collisions by renaming/removing some conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A Clojure library for word case conversions.
 
 ## News
 
+### To be released
+
+* **Breaking changes:**
+  * `CamelCase` has been renamed to `PascalCase`.
+  * `SNAKE_CASE` has been renamed to `SCREAMING_SNAKE_CASE`.
+  * `Snake_case` has been removed.
+* The above changes makes the library AOT compilable on case-insensitive filesystems.
+  In practice, this means you can e.g. use `lein ring uberwar` on Windows and OS X.
+
 ### 2014-07-28: 0.2.0
 
 * Supports ClojureScript!
@@ -16,10 +25,10 @@ A Clojure library for word case conversions.
 ```clojure
 (use 'camel-snake-kebab.core)
 
-(->CamelCase 'flux-capacitor)
-; => 'FluxCapacitor
+(->camelCase 'flux-capacitor)
+; => 'fluxCapacitor
 
-(->SNAKE_CASE "I am constant")
+(->SCREAMING_SNAKE_CASE "I am constant")
 ; => "I_AM_CONSTANT"
 
 (->kebab-case :object_id)
@@ -52,10 +61,9 @@ There are also functions that convert the value type for you:
 
 ## Available Conversion Functions
 
-* `->CamelCase`
+* `->PascalCase`
 * `->camelCase`
-* `->SNAKE_CASE`
-* `->Snake_case`
+* `->SCREAMING_SNAKE_CASE`
 * `->snake_case`
 * `->kebab-case`
 * `->Camel_Snake_Case`
@@ -65,10 +73,9 @@ You should be able to figure out all what all of them do.
 
 Yeah, and then there are the type-converting functions:
 
-* `->CamelCase{Keyword, String, Symbol}`
+* `->PascalCase{Keyword, String, Symbol}`
 * `->camelCase{Keyword, String, Symbol}`
-* `->SNAKE_CASE_{KEYWORD, STRING, SYMBOL}`
-* `->Snake_case_{keyword, string, symbol}`
+* `->SCREAMING_SNAKE_CASE_{KEYWORD, STRING, SYMBOL}`
 * `->snake_case_{keyword, string, symbol}`
 * `->kebab-case-{keyword, string, symbol}`
 * `->Camel_Snake_Case_{Keyword, String, Symbol}`
@@ -77,11 +84,6 @@ Yeah, and then there are the type-converting functions:
 ## Notes
 
 * Namespaced keywords and symbols will be rejected with an exception.
-
-* This library has function names that only differ in case and will not work if you AOT compile it to a
-  case-insensitive filesystem (on e.g. Windows and OS X). `lein ring uberwar` always uses AOT and is therefore not
-  compatible with this library on these systems. See [#15](https://github.com/qerub/camel-snake-kebab/issues/15) and
-  [lein-ring#120](https://github.com/weavejester/lein-ring/issues/120) for details.
 
 ## Serving Suggestions
 

--- a/src/camel_snake_kebab/core.cljx
+++ b/src/camel_snake_kebab/core.cljx
@@ -35,11 +35,10 @@
 
 ;; These are fully qualified to workaround some issue with ClojureScript:
 
-(defconversion "CamelCase"        clojure.string/capitalize clojure.string/capitalize "")
-(defconversion "Camel_Snake_Case" clojure.string/capitalize clojure.string/capitalize "_")
-(defconversion "camelCase"        clojure.string/lower-case clojure.string/capitalize "" )
-(defconversion "Snake_case"       clojure.string/capitalize clojure.string/lower-case "_")
-(defconversion "SNAKE_CASE"       clojure.string/upper-case clojure.string/upper-case "_")
-(defconversion "snake_case"       clojure.string/lower-case clojure.string/lower-case "_")
-(defconversion "kebab-case"       clojure.string/lower-case clojure.string/lower-case "-")
-(defconversion "HTTP-Header-Case" camel-snake-kebab.internals.misc/capitalize-http-header camel-snake-kebab.internals.misc/capitalize-http-header "-")
+(defconversion "PascalCase"           clojure.string/capitalize clojure.string/capitalize "")
+(defconversion "Camel_Snake_Case"     clojure.string/capitalize clojure.string/capitalize "_")
+(defconversion "camelCase"            clojure.string/lower-case clojure.string/capitalize "" )
+(defconversion "SCREAMING_SNAKE_CASE" clojure.string/upper-case clojure.string/upper-case "_")
+(defconversion "snake_case"           clojure.string/lower-case clojure.string/lower-case "_")
+(defconversion "kebab-case"           clojure.string/lower-case clojure.string/lower-case "-")
+(defconversion "HTTP-Header-Case"     camel-snake-kebab.internals.misc/capitalize-http-header camel-snake-kebab.internals.misc/capitalize-http-header "-")

--- a/test/camel_snake_kebab/core_test.cljx
+++ b/test/camel_snake_kebab/core_test.cljx
@@ -36,29 +36,27 @@
 (deftest format-case-test
   (testing "examples"
     (are [x y] (= x y)
-      'FluxCapacitor  (csk/->CamelCase 'flux-capacitor)
-      "I_AM_CONSTANT" (csk/->SNAKE_CASE "I am constant")
+      'fluxCapacitor  (csk/->camelCase 'flux-capacitor)
+      "I_AM_CONSTANT" (csk/->SCREAMING_SNAKE_CASE "I am constant")
       :object-id      (csk/->kebab-case :object_id)
       "X-SSL-Cipher"  (csk/->HTTP-Header-Case "x-ssl-cipher")
       :object-id      (csk/->kebab-case-keyword "object_id")))
 
   (testing "rejection of namespaced keywords and symbols"
-    (is (thrown? ExceptionInfo (csk/->CamelCase (keyword "a" "b"))))
-    (is (thrown? ExceptionInfo (csk/->CamelCase (symbol  "a" "b")))))
+    (is (thrown? ExceptionInfo (csk/->PascalCase (keyword "a" "b"))))
+    (is (thrown? ExceptionInfo (csk/->PascalCase (symbol  "a" "b")))))
 
   (testing "all the type preserving functions"
     (let
       [inputs    ["FooBar"
                   "fooBar"
                   "FOO_BAR"
-                  "Foo_bar"
                   "foo_bar"
                   "foo-bar"
                   "Foo_Bar"]
-       functions [csk/->CamelCase
+       functions [csk/->PascalCase
                   csk/->camelCase
-                  csk/->SNAKE_CASE
-                  csk/->Snake_case
+                  csk/->SCREAMING_SNAKE_CASE
                   csk/->snake_case
                   csk/->kebab-case
                   csk/->Camel_Snake_Case]
@@ -69,8 +67,8 @@
 
   (testing "some of the type converting functions"
     (are [x y] (= x y)
-      :FooBar   (csk/->CamelCaseKeyword  'foo-bar)
-      "FOO_BAR" (csk/->SNAKE_CASE_STRING :foo-bar)
+      :FooBar   (csk/->PascalCaseKeyword 'foo-bar)
+      "FOO_BAR" (csk/->SCREAMING_SNAKE_CASE_STRING :foo-bar)
       'foo-bar  (csk/->kebab-case-symbol "foo bar")))
 
   (testing "handling of blank input string"


### PR DESCRIPTION
Possible solution to #15. What do you folks think?