### PR TITLE
Docs to match latest clojure.core.memoize

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you're going to do case conversion in a hot spot, use [core.memoize](https://
 (use 'criterium.core)
 
 (def memoized->kebab-case
-  (fifo kebab/->kebab-case-keyword {} :fifo/threshold 512))
+  (fifo kebab/->kebab-case {} :fifo/threshold 512))
 
 (quick-bench (->kebab-case "firstName"))
 ; ... Execution time mean : 6,384971 µs ...

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you're going to do case conversion in a hot spot, use [core.memoize](https://
 (use 'criterium.core)
 
 (def memoized->kebab-case
-  (fifo kebab/->kebab-case {} :fifo/threshold 512))
+  (fifo ->kebab-case {} :fifo/threshold 512))
 
 (quick-bench (->kebab-case "firstName"))
 ; ... Execution time mean : 6,384971 µs ...

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you're going to do case conversion in a hot spot, use [core.memoize](https://
 (use 'criterium.core)
 
 (def memoized->kebab-case
-  (memo-fifo ->kebab-case 512))
+  (fifo kebab/->kebab-case-keyword {} :fifo/threshold 512))
 
 (quick-bench (->kebab-case "firstName"))
 ; ... Execution time mean : 6,384971 µs ...


### PR DESCRIPTION
Using `(memo-fifo ->kebab-case 512)` gives warning 

```
WARNING - Deprecated construction method for fifo cache; prefered way is: (clojure.core.memoize/fifo function <base> <:fifo/threshold num>)
```