### PR TITLE
Add public alter-name function to core

### DIFF
--- a/src/camel_snake_kebab/core.cljc
+++ b/src/camel_snake_kebab/core.cljc
@@ -1,8 +1,8 @@
 (ns camel-snake-kebab.core
   (:require [clojure.string]
+            [camel-snake-kebab.internals.alter-name :as internals]
             [camel-snake-kebab.internals.misc :as misc]
-            #?(:clj [camel-snake-kebab.internals.macros :refer [defconversion]]
-               :cljs [camel-snake-kebab.internals.alter-name])) ;; Needed for expansion of defconversion
+            #?(:clj [camel-snake-kebab.internals.macros :refer [defconversion]]))
   #?(:cljs (:require-macros [camel-snake-kebab.internals.macros :refer [defconversion]])))
 
 (defn convert-case
@@ -10,6 +10,12 @@
   word, remaining words, and the separator."
   [first-fn rest-fn sep s & rest]
   (apply misc/convert-case first-fn rest-fn sep s rest))
+
+(defn alter-name
+  "Alters the name of s with f. If s is a string it is used as the name
+  and supplied to f directly."
+  [s f]
+  (internals/alter-name s f))
 
 ;; These are fully qualified to workaround some issue with ClojureScript:
 

--- a/src/camel_snake_kebab/internals/macros.clj
+++ b/src/camel_snake_kebab/internals/macros.clj
@@ -1,6 +1,5 @@
 (ns camel-snake-kebab.internals.macros
-  (:require [clojure.string :refer [join]]
-            [camel-snake-kebab.internals.alter-name :refer [alter-name]]
+  (:require [camel-snake-kebab.internals.alter-name :refer [alter-name]]
             [camel-snake-kebab.internals.misc :refer [convert-case]]))
 
 (defn type-preserving-function [case-label first-fn rest-fn sep]


### PR DESCRIPTION
Hello!

I added these changes due to an error with `clojure.tools.namespace/refresh` we were having in one project. We tried creating a new project with only `clojure.tools.namespace` and `camel-snake-kebab` but we couldn't reproduce the issue, so take this PR with a grain of salt.

The issue we were having was:

```
:error-while-loading camel-snake-kebab.core
#error {
 :cause "camel-snake-kebab.internals.alter-name"
 :via
 [{:type clojure.lang.Compiler$CompilerException
   :message "java.lang.ClassNotFoundException: camel-snake-kebab.internals.alter-name, compiling:(camel_snake_kebab/core.cljc:16:1)"

   :at [clojure.lang.Compiler analyzeSeq "Compiler.java" 6875]}
  {:type java.lang.ClassNotFoundException
   :message "camel-snake-kebab.internals.alter-name"
   :at [java.net.URLClassLoader findClass "URLClassLoader.java" 381]}]
 :trace
 [[java.net.URLClassLoader findClass "URLClassLoader.java" 381]
  [clojure.lang.DynamicClassLoader findClass "DynamicClassLoader.java" 69]
  [java.lang.ClassLoader loadClass "ClassLoader.java" 424]
  [clojure.lang.DynamicClassLoader loadClass "DynamicClassLoader.java" 77]
  [java.lang.ClassLoader loadClass "ClassLoader.java" 357]
  [java.lang.Class forName0 "Class.java" -2]
  [java.lang.Class forName "Class.java" 348]
  [clojure.lang.RT classForName "RT.java" 2168]
  [clojure.lang.RT classForName "RT.java" 2177]
  [clojure.lang.Compiler$HostExpr maybeClass "Compiler.java" 1030]
  [clojure.lang.Compiler macroexpand1 "Compiler.java" 6807]
  [clojure.lang.Compiler analyzeSeq "Compiler.java" 6854]
  [clojure.lang.Compiler analyze "Compiler.java" 6669]
  [clojure.lang.Compiler analyze "Compiler.java" 6625]
  [clojure.lang.Compiler$BodyExpr$Parser parse "Compiler.java" 6001]
  [clojure.lang.Compiler$LetExpr$Parser parse "Compiler.java" 6319]
  [clojure.lang.Compiler analyzeSeq "Compiler.java" 6868]
  [clojure.lang.Compiler analyze "Compiler.java" 6669]
  [clojure.lang.Compiler analyzeSeq "Compiler.java" 6856]
  [clojure.lang.Compiler analyze "Compiler.java" 6669]
  [clojure.lang.Compiler analyze "Compiler.java" 6625]
  [clojure.lang.Compiler$BodyExpr$Parser parse "Compiler.java" 6001]
```

And this commit fixes it by adding a public `alter-name` function to `camel-kebab-case.core` that acts as a wrapper around the protocol function `camel-snake-kebab.internals.alter-name` (just as is done with`convert-case`).

Thank you!