### PR TITLE
Don't transform integer keys

### DIFF
--- a/src/camel_snake_kebab/internals/macros.cljc
+++ b/src/camel_snake_kebab/internals/macros.cljc
@@ -22,7 +22,9 @@
                  (symbol)))]
     (for [[type-label type-converter] {"string" `identity "symbol" `symbol "keyword" `keyword}]
       `(defn ~(make-name type-label) [s# & rest#]
-         (~type-converter (apply convert-case ~first-fn ~rest-fn ~sep (name s#) rest#))))))
+         (if (integer? s#)
+           s#
+           (~type-converter (apply convert-case ~first-fn ~rest-fn ~sep (name s#) rest#)))))))
 
 (defmacro defconversion [case-label first-fn rest-fn sep]
   `(do  ~(type-preserving-function  case-label first-fn rest-fn sep)


### PR DESCRIPTION
This change allows integer keys to pass through `key-transformation` unchanged. We often process objects with integer keys and the current implementation makes use of the `name` built-in clj function, which throws an exception for integer values. See issue #62. Passes all tests okay - let me know if a new test case is required.