### PR TITLE
Fix minor typo in GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
       with:
         path: |
           ~/.m2/repository
-        key: $${ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
-        restore-keys: $${ runner.os }}-cljdeps-
+        key: ${{ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
+        restore-keys: ${{ runner.os }}-cljdeps-
 
     - name: Setup Java
       uses: actions/setup-java@v4


### PR DESCRIPTION
Thanks for migrating this project to GitHub Actions @lread 😄 !!

I copy-pasted `actions/cache` step from this project and noticed what appears to be a minor typo introduced by pull request #85: I believe `$${ ... }}}` is intended to be `${{ ... }}`.

## Before 

You can see the behavior in the GitHub Action logs:

### Cache Initialized

https://github.com/clj-commons/camel-snake-kebab/actions/runs/14070324243/job/39402771903#step:17:4

> Cache saved with key: $${ runner.os }}-cljdeps-0d79e0f3eff84b57bdc9bfb04535bd70fc45ee1dfc6552f539bd17c3c61b9a4a

### Cache Restored

https://github.com/clj-commons/camel-snake-kebab/actions/runs/14316100998/job/40122452827#step:3:18

> Cache restored from key: $${ runner.os }}-cljdeps-0d79e0f3eff84b57bdc9bfb04535bd70fc45ee1dfc6552f539bd17c3c61b9a4a

## After

But I think the cache key is intended to include the OS name (e.g., `Linux`) as seen here:

### Cache Restored (with appropriate key)

https://github.com/samumbach/shape-shifter/actions/runs/15696931148/job/44223716514#step:3:17

> Cache restored from key: Linux-cljdeps-2f727220fb13e009f2d78573fd6ac39503da2a319b27e4125055e320efec3bfb